### PR TITLE
Add support for Brazilian Portuguese Core Rules

### DIFF
--- a/swim/scripts/api.js
+++ b/swim/scripts/api.js
@@ -223,6 +223,7 @@ export class api {
     else if (game.modules.get("deadlands-core-rules")?.active) { officialClass = '<div class="swade-core">' }
     else if (game.modules.get("sprawl-core-rules")?.active) { officialClass = '<div class="sprawl-core">' }
     else if (game.modules.get("swade-core-rules")?.active) { officialClass = '<div class="swade-core">' }
+    else if (game.modules.get("swade-core-rules-ptbr")?.active) { officialClass = '<div class="swade-core">' }
     return officialClass
   }
   // Get SFX

--- a/swim/scripts/swim_modules/deviation.js
+++ b/swim/scripts/swim_modules/deviation.js
@@ -7,9 +7,6 @@
 export async function deviation_script(weapontype = false, range = false) {
     const chatimage = "https://raw.githubusercontent.com/brunocalado/mestre-digital/master/Foundry%20VTT/Macros/Savage%20Worlds/icons/clock.webp";
 
-    let coreRules = false;
-    if (game.modules.get("swade-core-rules")?.active) { coreRules = true; }
-
     if (weapontype && range) {
         rollForIt()
     } else {
@@ -66,13 +63,23 @@ export async function deviation_script(weapontype = false, range = false) {
         let direction = await new Roll('1d12').roll();
         let roll = await new Roll(die).roll();
         let message = `<h2>Deviation</h2>`;
-        if (coreRules === true) { message = `<div class="swade-core"><h2>@Compendium[swade-core-rules.swade-rules.Deviation]{Deviation}</h2>`; }
+        let coreRules = "";
+        if (game.modules.get("swade-core-rules")?.active) {
+            coreRules = "en";
+        } else if (game.modules.get("swade-core-rules-ptbr")?.active) {
+            coreRules = "ptbr";
+        }
+        if (coreRules === "en") {
+            message = `<div class="swade-core"><h2>@Compendium[swade-core-rules.swade-rules.Deviation]{Deviation}</h2>`;
+        } else if (coreRules === "ptbr") {
+            message = `<div class="swade-core"><h2>@UUID[Compendium.swade-core-rules-ptbr.swade-rules.JournalEntry.YqkGb1HsubFuZycb.JournalEntryPage.vL3TExJeOXzRXAi3#desvio]{Desvio}</h2>`;
+        }
         message += `<p>Move the blast <b>${roll.total * rangeMultiplier}"</b> to <b style="color:red">${direction.total}</b> O'Clock.</p>`;
         if (directionCheck(direction.total)) {
             message += `<p><b style="color:red">A weapon can never deviate more than half the distance to the original target (that keeps it from going behind the thrower).</b></p>`;
         }
         message += `<p style="text-align:center"><img style="vertical-align:middle; border: none;" src=${chatimage} width="200" height="200"><p>`;
-        if (coreRules === true) { message += `</div>` }
+        if (coreRules) { message += `</div>` }
 
         let tempChatData = {
             //type: CHAT_MESSAGE_TYPES.ROLL,

--- a/swim/scripts/swim_modules/fear_table.js
+++ b/swim/scripts/swim_modules/fear_table.js
@@ -232,6 +232,7 @@ async function gain_phobia(actor, major, total) {
     let originalText = ``
     if (game.modules.get("swpf-core-rules")?.active) { hindranceCompendium = "swpf-core-rules.swpf-hindrances" }
     else if (game.modules.get("swade-core-rules")?.active) { hindranceCompendium = "swade-core-rules.swade-hindrances" }
+    else if (game.modules.get("swade-core-rules-ptbr")?.active) { hindranceCompendium = "swade-core-rules-ptbr.swade-hindrances" }
     if (hindranceCompendium) {
         //Get the phobia hindrance from compendium:
         const pack = game.packs.get(hindranceCompendium)

--- a/swim/scripts/swim_modules/radiation_centre.js
+++ b/swim/scripts/swim_modules/radiation_centre.js
@@ -136,11 +136,14 @@ export async function radiation_centre_script() {
 
     // Main Dialogue
     let { ___, ____, totalBennies } = await swim.check_bennies(token)
+    let compendiumLink = game.i18n.localize("SWIM.hazard-radiation");
+    if (game.modules.get("swade-core-rules")?.active) { compendiumLink = `@UUID[Compendium.swade-core-rules.swade-rules.swadecor04theadv.JournalEntryPage.04radiation00000]{${game.i18n.localize("SWIM.hazard-radiation")}` }
+    else if (game.modules.get("swade-core-rules-ptbr")?.active) { compendiumLink = `@UUID[Compendium.swade-core-rules-ptbr.swade-rules.JournalEntry.iVtlDDh7A3L9Lbhs.JournalEntryPage.x6XR8bHzQwnKve5r#radiacao]{Radiação}` }
     new Dialog({
         title: 'Radiation Centre',
         content: await TextEditor.enrichHTML(`<form class="swade-core">
          ${game.i18n.format("SWIM.dialogue-radiationCentre-1", {fv: fv, fm: fm, totalBennies: totalBennies})}
-         <p><i class="fas fa-radiation"></i> @UUID[Compendium.swade-core-rules.swade-rules.swadecor04theadv.JournalEntryPage.04radiation00000]{${game.i18n.localize("SWIM.hazard-radiation")}} ${game.i18n.localize("SWIM.dialogue-radiationCentre-2")}
+         <p><i class="fas fa-radiation"></i> ${compendiumLink}} ${game.i18n.localize("SWIM.dialogue-radiationCentre-2")}
      </form>`, { async: true }),
         buttons: buttonsMain,
         default: "one",
@@ -259,7 +262,7 @@ export async function radiation_centre_script() {
                 actorName: actor.name,
                 class: 'swade-core',
                 img: 'modules/succ/assets/icons/0-irradiated.svg'
-            }))} @UUID[Compendium.swade-core-rules.swade-rules.swadecor04theadv.JournalEntryPage.04disease0000000#disease-categories]{${game.i18n.localize("SWIM.disease-chronic").toLowerCase()}}. 
+            }))} @UUID[Compendium.swade-core-rules.swade-rules.swadecor04theadv.JournalEntryPage.04disease0000000#disease-categories]{${game.i18n.localize("SWIM.disease-chronic").toLowerCase()}}.
             ${game.i18n.format(game.i18n.format("SWIM.chatMessage-radPoisoning-2", {
                 actorName: actor.name,
             }))}`,

--- a/swim/scripts/swim_modules/scale_calculator.js
+++ b/swim/scripts/swim_modules/scale_calculator.js
@@ -8,15 +8,13 @@ export async function scale_calculator() {
     const chatimage = "icons/tools/hand/scale-balances-merchant-brown.webp";
 
     /* Size Scale p106 SWADE
-    
+
     source: https://raw.githubusercontent.com/brunocalado/mestre-digital/master/Foundry%20VTT/Macros/Savage%20Worlds/SizeScaleCalculator.js
     icon: icons/tools/hand/scale-balances-merchant-brown.webp
     */
 
     let tokenActor = canvas.tokens.controlled[0];
     let tokenTarget = Array.from(game.user.targets)[0];
-    let coreRules = false;
-    if (game.modules.get("swade-core-rules")?.active) { coreRules = true; }
 
     if (tokenActor === undefined || tokenTarget === undefined) {
         ui.notifications.warn(game.i18n.localize("SWIM.notification-selectAndTargetOneToken"));
@@ -37,9 +35,18 @@ export async function scale_calculator() {
             let targetModifier = sizeToModifier(targetSize);
             let modifier = calc(actorModifier, targetModifier);
 
+            let coreRules = "";
+            if (game.modules.get("swade-core-rules")?.active) {
+                coreRules = "en";
+            } else if (game.modules.get("swade-core-rules-ptbr")?.active) {
+                coreRules = "ptbr";
+            }
+
             let message = `<h2><img style="vertical-align:middle" src=${chatimage} width="28" height="28"> Size & Scale Calculator</h2>`;
-            if (coreRules === true) {
+            if (coreRules === "en") {
                 message = `<div class="swade-core"><h2><img style="vertical-align:middle" src=${chatimage} width="28" height="28"> @Compendium[swade-core-rules.swade-rules.mbP0fwcquD98QtwX]{Size & Scale} Calculator</h2>`;
+            } else if (coreRules === "ptbr") {
+                message = `<div class="swade-core"><h2><img style="vertical-align:middle" src=${chatimage} width="28" height="28"> Calculadora de @UUID[Compendium.swade-core-rules-ptbr.swade-rules.JournalEntry.YqkGb1HsubFuZycb.JournalEntryPage.mwLhiYqMcWKnTdyK]{Tamanho e Escala}</h2>`;
             }
             message += `<ul><li><b>${tokenActor.name}:</b> Size = ${actorSize} / Modifier = ${actorModifier}</li>`;
             message += `<li><b>${tokenTarget.name}:</b> Size = ${targetSize} / Modifier = ${targetModifier}</li></ul>`;
@@ -54,12 +61,14 @@ export async function scale_calculator() {
                     message += ` and has Swat*.</li></ul>`;
                 } else { message += `.</li></ul>` }
                 if ((actorSwat && targetSwat) || (actorSwat || targetSwat)) {
-                    if (coreRules === true) {
+                    if (coreRules === "en") {
                         message += `<p>*<b>@Compendium[swade-core-rules.swade-rules.q5sk5hEw6TED0FOU]{Swat}:</b> Ignore up to 4 points of penalties from Scale for the specified action(s).</p>`;
+                    } else if (coreRules === "ptbr") {
+                        message += `<p>*<b>@UUID[Compendium.swade-core-rules-ptbr.swade-rules.JournalEntry.i1doThAoZoNyspVL.JournalEntryPage.2PsyiX7nTwDbDEWb]{Esmagar}:</b> Ignora até 4 pontos de penalidades por Escala para a ação específica.</p>`;
                     } else {
                         message += `<p>*<b>Swat:</b> Ignore up to 4 points of penalties from Scale for the specified action(s).</p>`;
                     }
-                    if (coreRules === true) {
+                    if (coreRules) {
                         message += `</div>`;
                     }
                 }


### PR DESCRIPTION
Adds the `swade-core` styling for worlds where the Brazilian Portuguese Core Rules are active.
Adds links to the Brazilian Portuguese Core Rules.

`coreRules` variable became a string to distinguish between rulesets of different languages ("en" and "ptbr" on this PR).

I suggest an API function that checks and returns the actual string should be implemented to avoid code duplication and simplify handling that (on this PR, deviation.js and scale_calculator.js share some code).

As you said on Discord, there should probably be a JSON with the different links to also handle it better for more Core Rules.

