### PR TITLE
Chase cards macro fixed in Foundry V12.331

### DIFF
--- a/swim/scripts/swim_modules/chase_setup.js
+++ b/swim/scripts/swim_modules/chase_setup.js
@@ -189,7 +189,7 @@
             }
 
             const tileData = {
-                img: theImage,
+                texture: { src: theImage },
                 width: cardWidth,
                 height: cardHeight,
                 x: xPosition,


### PR DESCRIPTION
The issue with swim cards not rendering for the chase macro has been resolved. The fix involved updating the property used for the tile's image in line 192. Specifically, the property was changed from:
```
img: theImage,
```
To:
```
texture: { src: theImage },
```
The updated code is as follows:
```
const tileData = {
    texture: { src: theImage },
    width: cardWidth,
    height: cardHeight,
    x: xPosition,
    y: yPosition,
    'flags.swim.isChaseCard': true
};
```
This adjustment ensures that the tile renders correctly by using the proper structure for defining the texture.
